### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -737,7 +737,8 @@ if ("undefined" == typeof jQuery)
             a(document).on("click.bs.modal.data-api", '[data-toggle="modal"]', function(c) {
                 var d = a(this)
                     , e = d.attr("href")
-                    , f = a(d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, ""))
+                    , selector = d.attr("data-target") || (e && e.replace(/.*(?=#[^\s]+$)/, ""))
+                    , f = a(document).find(selector)
                     , g = f.data("bs.modal") ? "toggle" : a.extend({
                     remote: !/#/.test(e) && e
                 }, f.data(), d.data());


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/6](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/6)

The safest way to fix the vulnerability is to ensure that the value of the `data-target` attribute (or derived selector) is **never interpreted as HTML** by jQuery. Instead of passing the potentially attacker-controlled value to `a(...)` directly—which can interpret it as HTML—use the value with a strictly selector-only API such as `.find()` on a trusted context, or validate and sanitize it before use.

In this specific case:
- On line 740:  
  ```js
  var f = a(d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, ""));
  ```
  Should be changed so that the selector from `d.attr("data-target") || ...` is **not** passed directly to jQuery's global `$`/`a` function, but instead used as a selector-only argument in `.find()` on a trusted parent, or by strictly whitelisting selectors (e.g., IDs).

**BEST PRACTICE in Bootstrap 3:**  
- Bootstrap 3 recommends that the selector should always be an ID (starting with "#").
- Parse out only the fragment that starts with "#" (forcefully, so attacker cannot inject other things).
- Use document.getElementById or use jQuery's attribute selector, e.g. `a(document.getElementById(...))`.
- Or, use a context-bound `.find(selector)` off document or another trusted parent, e.g. `a(document).find(selector)`.

**Minimal fix:**  
Parse out only a valid ID from the selector. If we're expecting always an "#id", then:
```js
var selector = d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, "");
if (selector && selector.charAt(0) === '#') {
    var f = a(document).find(selector);
} else {
    var f = a(); // Empty jQuery object if not a valid selector
}
```
Or, directly use document.getElementById:
```js
var selector = d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, "");
var fId = selector && selector.charAt(0) === '#' ? selector.slice(1) : null;
var f = fId ? a(document.getElementById(fId)) : a();
```

**For maximum compatibility and minimal change:**
- Replace the direct use of `a(selector)` with `a(document).find(selector)`.

Edit only line 740, replacing:
```js
var f = a(d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, ""));
```
with:
```js
var selector = d.attr("data-target") || (e && e.replace(/.*(?=#[^\s]+$)/, ""));
var f = a(document).find(selector);
```
If `selector` is an invalid value, `.find(selector)` does not evaluate HTML, just selectors (safe).

No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
