### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -449,7 +449,7 @@ if ("undefined" == typeof jQuery)
             var c = b.attr("data-target");
             c || (c = b.attr("href"),
                 c = c && /#[A-Za-z]/.test(c) && c.replace(/.*(?=#[^\s]*$)/, ""));
-            var d = c && a(c);
+            var d = c && $(document).find(c);
             return d && d.length ? d : b.parent()
         }
         function c(c) {


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/5](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/5)

To safely convert `data-target`/`href` into a jQuery selector when extracting values from the DOM, never use the selector directly as an argument to `$()` or `a()` unless you have validated its content. Instead, ensure you only use it to select existing DOM elements and not interpret it as HTML. The safest fix is to use `document.querySelector` if you expect an ID or a class, or restrict the string with a regular expression (e.g., allowing only `#something` forms). Alternatively, use `a.find(c)` or `$(document).find(c)`, ensuring the selector finds elements already in the DOM, instead of creating new elements.

For the code in question, the best fix is to replace `var d = c && a(c);` with a contextually safe search, such as `var d = c && $(document).find(c);`. If you need to support both cases (where `c` is a selector), you may check that `c` begins with `#`, or otherwise reject/ignore it. The edit is in `public/themes/Default/js/bootstrap.js`, lines surrounding line 452.

No additional imports are required, as jQuery is already in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
