### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -64,6 +64,12 @@ if ("undefined" == typeof jQuery)
         };
         d.VERSION = "3.3.7",
             d.TRANSITION_DURATION = 150,
+            d._isSafeSelector = function(f) {
+                // Allow only simple ID selectors like "#my-alert"
+                if (!f || "string" != typeof f) return !1;
+                return /^#[A-Za-z][A-Za-z0-9\-_:.]*$/.test(f);
+            }
+            ,
             d.prototype.close = function(b) {
                 function c() {
                     g.detach().trigger("closed.bs.alert").remove()
@@ -72,7 +78,8 @@ if ("undefined" == typeof jQuery)
                     , f = e.attr("data-target");
                 f || (f = e.attr("href"),
                     f = f && f.replace(/.*(?=#[^\s]*$)/, ""));
-                var g = a("#" === f ? [] : f);
+                d._isSafeSelector(f) || (f = null);
+                var g = f ? a("#" === f ? [] : f) : a();
                 b && b.preventDefault(),
                 g.length || (g = e.closest(".alert")),
                     g.trigger(b = a.Event("close.bs.alert")),


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/2](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/2)

In general, the problem arises because a string taken from the DOM (`data-target` / `href`) is passed directly into `a(...)`/`$(...)`. jQuery interprets this parameter as either a selector or an HTML fragment, which can allow HTML injection / XSS when the string is attacker-controlled. To fix this, we must ensure that the string is only ever treated as a selector (and only of the allowed, safe form), and never as arbitrary HTML. This can be done by validating it against a whitelist (e.g., allow only simple ID selectors like `#something`) and then using a context that does not reinterpret it as HTML.

For this specific code, the simplest safe adjustment that preserves existing functionality is:

1. Validate `f` before using it.
2. If `f` is not of a safe form (e.g., not a simple `#id` selector), ignore it and fall back to `e.closest(".alert")`, which is the current fallback.
3. When resolved, continue to use `a(f)` as a selector—Bootstrap expects selectors here—but only after ensuring it is just a selector, not arbitrary HTML.

We can add a small helper inside this IIFE to check that `f` is a simple ID selector (`/^#[A-Za-z][A-Za-z0-9\-_:.]*$/`). If the string fails validation, we set `f` to `null` and let the following `g.length || (g = e.closest(".alert"))` logic choose the closest `.alert` instead. This preserves behavior for all normal Bootstrap usage (where `data-target="#myAlert"` or `href="#myAlert"`), but prevents harmful HTML/selector strings from being used directly.

Concretely:

- Inside the `+function(a) { ... }(jQuery)` that defines the alert plugin, define a local function `isSafeSelector(sel)` before `d.prototype.close`.
- In `d.prototype.close`, after computing `f` from `data-target`/`href`, validate `f`. If `!isSafeSelector(f)`, set `f = null`.
- Change the line `var g = a("#" === f ? [] : f);` to safely handle `null`/unsafe values: if `f` is falsy, initialize `g` as an empty jQuery object, so the later `g.length || (g = e.closest(".alert"))` fallback kicks in.

No external dependencies or imports are needed; everything is self-contained within this file and closure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
