### PR TITLE
Potential fix for code scanning alert no. 30: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -79,7 +79,11 @@ if ("undefined" == typeof jQuery)
                 f || (f = e.attr("href"),
                     f = f && f.replace(/.*(?=#[^\s]*$)/, ""));
                 d._isSafeSelector(f) || (f = null);
-                var g = f ? a("#" === f ? [] : f) : a();
+                var g = a();
+                if (f && "#" !== f) {
+                    var h = document.getElementById(f.slice(1));
+                    h && (g = a(h));
+                }
                 b && b.preventDefault(),
                 g.length || (g = e.closest(".alert")),
                     g.trigger(b = a.Event("close.bs.alert")),


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/30](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/30)

General fix: avoid APIs that can reinterpret strings as HTML (`$()`) when handling untrusted DOM text. Since `data-target` is intended to be an ID selector, resolve it strictly as an element ID with `document.getElementById`, then wrap the resulting element in jQuery.

Best fix in this snippet (same functionality, safer sink):
- In `public/themes/Default/js/bootstrap.js`, inside `d.prototype.close`, replace:
  - `var g = f ? a("#" === f ? [] : f) : a();`
- With logic that:
  - handles `"#"` as empty selection,
  - strips leading `#`,
  - uses `document.getElementById(...)`,
  - wraps found element via `a(elem)` or falls back to empty `a()`.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
