### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -964,10 +964,33 @@ if ("undefined" == typeof jQuery)
                 this.arrow().css(c ? "left" : "top", 50 * (1 - a / b) + "%").css(c ? "top" : "left", "")
             }
             ,
+            function sanitizeHtml(a) {
+                var b = document.createElement("div");
+                b.innerHTML = a == null ? "" : String(a);
+                var c = b.getElementsByTagName("*")
+                    , d = ["script", "iframe", "object", "embed", "link", "meta", "style"];
+                for (var e = c.length - 1; e >= 0; e--) {
+                    var f = c[e]
+                        , g = f.nodeName.toLowerCase();
+                    if (d.indexOf(g) !== -1) {
+                        f.parentNode.removeChild(f);
+                        continue
+                    }
+                    for (var h = f.attributes.length - 1; h >= 0; h--) {
+                        var i = f.attributes[h]
+                            , j = i.name.toLowerCase()
+                            , k = (i.value || "").replace(/\s+/g, "").toLowerCase();
+                        ("on" === j.slice(0, 2) || ("src" === j || "href" === j || "xlink:href" === j) && 0 === k.indexOf("javascript:")) && f.removeAttribute(i.name)
+                    }
+                }
+                return b.innerHTML
+            }
+            ,
             c.prototype.setContent = function() {
                 var a = this.tip()
-                    , b = this.getTitle();
-                a.find(".tooltip-inner")[this.options.html ? "html" : "text"](b),
+                    , b = this.getTitle()
+                    , c = this.options.html ? sanitizeHtml(b) : b;
+                a.find(".tooltip-inner")[this.options.html ? "html" : "text"](c),
                     a.removeClass("fade in top bottom left right")
             }
             ,

--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -980,7 +980,7 @@ if ("undefined" == typeof jQuery)
                         var i = f.attributes[h]
                             , j = i.name.toLowerCase()
                             , k = (i.value || "").replace(/\s+/g, "").toLowerCase();
-                        ("on" === j.slice(0, 2) || ("src" === j || "href" === j || "xlink:href" === j) && 0 === k.indexOf("javascript:")) && f.removeAttribute(i.name)
+                        ("on" === j.slice(0, 2) || ("src" === j || "href" === j || "xlink:href" === j) && (0 === k.indexOf("javascript:") || 0 === k.indexOf("data:") || 0 === k.indexOf("vbscript:"))) && f.removeAttribute(i.name)
                     }
                 }
                 return b.innerHTML


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/7](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/7)

General fix: never pass DOM-derived strings directly to `.html()`. If rich HTML is truly required, sanitize first with a robust HTML sanitizer; otherwise render as text.

Best fix here without changing broad functionality: sanitize tooltip content before writing it when `this.options.html` is enabled, and keep existing `.text()` behavior otherwise. In `public/themes/Default/js/bootstrap.js`, update `c.prototype.setContent` so that:
- it computes `var c = this.options.html ? sanitizeHtml(b) : b;`
- then writes with `.html(c)` for html mode and `.text(c)` for text mode.
- add a local helper `sanitizeHtml` in the same closure (near tooltip methods) that strips dangerous constructs (script tags, event-handler attrs, `javascript:` URLs).  
Given constraints (single shown file, no dependency changes), implement an inline sanitizer helper in this file and call it only for html mode.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
