### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -748,7 +748,14 @@ if ("undefined" == typeof jQuery)
             a(document).on("click.bs.modal.data-api", '[data-toggle="modal"]', function(c) {
                 var d = a(this)
                     , e = d.attr("href")
-                    , f = a(d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, ""))
+                    , target = d.attr("data-target") || e && e.replace(/.*(?=#[^\s]+$)/, "")
+                    , targetEl = null;
+                try {
+                    targetEl = target ? document.querySelector(target) : null
+                } catch (h) {
+                    targetEl = null
+                }
+                var f = targetEl ? a(targetEl) : a()
                     , g = f.data("bs.modal") ? "toggle" : a.extend({
                     remote: !/#/.test(e) && e
                 }, f.data(), d.data());


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/6](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/6)

Use selector-only resolution instead of directly constructing a jQuery object from untrusted text.

Best fix here (minimal behavior change):  
1. Keep extracting the raw target string exactly as now.  
2. Resolve it via `document.querySelector(...)` (CSS selector only; never HTML parsing).  
3. Wrap the found element with `a(...)` if found; otherwise use an empty jQuery set `a()`.  
4. Guard invalid selectors with `try/catch` to avoid runtime errors.

Edit only `public/themes/Default/js/bootstrap.js` around line 751 where `f` is currently assigned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
