### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -460,7 +460,7 @@ if ("undefined" == typeof jQuery)
             var c = b.attr("data-target");
             c || (c = b.attr("href"),
                 c = c && /#[A-Za-z]/.test(c) && c.replace(/.*(?=#[^\s]*$)/, ""));
-            var d = c && a(c);
+            var d = c && a(a.find(c));
             return d && d.length ? d : b.parent()
         }
         function c(c) {


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/5](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/5)

General fix: do not pass untrusted DOM text directly into `jQuery(...)` when a selector is intended. Use an API that always treats input as a selector (for example `$.find`) and then wrap the returned elements with jQuery.

Best minimal fix in `public/themes/Default/js/bootstrap.js` (around lines 459–464): replace `var d = c && a(c);` with a selector-only lookup path, e.g. `var d = c && a(a.find(c));`. This preserves behavior (returns a jQuery collection for matching elements) while preventing HTML interpretation from untrusted `data-target`.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
