### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -343,7 +343,7 @@ if ("undefined" == typeof jQuery)
         "use strict";
         function b(b) {
             var c, d = b.attr("data-target") || (c = b.attr("href")) && c.replace(/.*(?=#[^\s]+$)/, "");
-            return a(d)
+            return d ? a.find(d) : a()
         }
         function c(b) {
             return this.each(function() {


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/4](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/4)

The best fix is to ensure the value from `data-target`/`href` is treated **only as a selector**, never as HTML. In this snippet, replace `return a(d)` with a selector-only lookup rooted in the document via `a.find(d)` (or equivalent safe selector-only API), and keep a safe fallback when `d` is empty.

In `public/themes/Default/js/bootstrap.js`, inside the collapse helper `function b(b)` (around lines 344–347), change the return logic:
- Keep existing extraction of `d`.
- If `d` is present, resolve via selector-only API (`a.find(d)`), not `a(d)`.
- If absent, return an empty jQuery set (`a()`), preserving behavior without introducing errors.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
