### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -321,7 +321,11 @@ if ("undefined" == typeof jQuery)
             }
         ;
         var e = function(c) {
-            var d, e = a(this), f = a(e.attr("data-target") || (d = e.attr("href")) && d.replace(/.*(?=#[^\s]+$)/, ""));
+            var d, e = a(this), fSelector = e.attr("data-target") || (d = e.attr("href")) && d.replace(/.*(?=#[^\s]+$)/, ""), f = a();
+            if (fSelector && /^#[A-Za-z][\w\-\:\.]*$/.test(fSelector)) {
+                var fElement = document.getElementById(fSelector.slice(1));
+                fElement && (f = a(fElement))
+            }
             if (f.hasClass("carousel")) {
                 var g = a.extend({}, f.data(), e.data())
                     , h = e.attr("data-slide-to");


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/3](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/3)

Use selector-only lookup instead of feeding attribute text into the jQuery constructor.

Best fix in this file: in the carousel data-api handler (around line 324), replace:

- `a(e.attr("data-target") || ... )`

with logic that:

1. Reads `data-target` / `href` into a string.
2. Validates it is an ID fragment selector beginning with `#`.
3. Resolves it via `document.getElementById(...)` (or equivalent selector-only API), then wraps the resulting element with `a(...)`.

This preserves behavior (targeting a carousel by ID) while preventing HTML interpretation of attacker-controlled strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
