### PR TITLE
Potential fix for code scanning alert no. 29: Replacement of a substring with itself

### DIFF
--- a/public/themes/panel/js/custom.js
+++ b/public/themes/panel/js/custom.js
@@ -10,7 +10,7 @@ function ToSeoUrl(textString) {
     textString = textString.replace(/£/, "");
     textString = textString.replace(/^/, "");
     textString = textString.replace(/#/, "");
-    textString = textString.replace(/$/, "");
+    textString = textString.replace(/\$/g, "");
     textString = textString.replace(/\+/g, "");
     textString = textString.replace(/%/g, "");
     textString = textString.replace(/½/g, "");


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/29](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/29)

To fix this without changing intended functionality, replace the anchor regex `/$/` with a regex that matches a **literal dollar sign**, escaped as `/\$/g`.  
This aligns with the sanitization pattern used throughout the function (removing unwanted punctuation), and ensures `$` characters are actually removed when present.

Edit only `public/themes/panel/js/custom.js`, in `ToSeoUrl`, at the current line:
- Change `textString = textString.replace(/$/, "");`
to:
- `textString = textString.replace(/\$/g, "");`

No imports, helper methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
