### PR TITLE
Potential fix for code scanning alert no. 28: Replacement of a substring with itself

### DIFF
--- a/public/themes/panel/js/custom.js
+++ b/public/themes/panel/js/custom.js
@@ -8,7 +8,6 @@ function ToSeoUrl(textString) {
     textString = textString.replace(/!/g, "");
     textString = textString.replace(/’/, "");
     textString = textString.replace(/£/, "");
-    textString = textString.replace(/^/, "");
     textString = textString.replace(/#/, "");
     textString = textString.replace(/\$/g, "");
     textString = textString.replace(/\+/g, "");


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/28](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/28)

General fix: remove or correct any `replace` call where the pattern matches an empty string position and the replacement is also effectively empty/no-op.

Best fix here (without changing existing functionality): delete the specific no-op line in `public/themes/panel/js/custom.js`:

- Remove line:
  - `textString = textString.replace(/^/, "");`

This preserves runtime behavior (because the line currently has no effect) while resolving the CodeQL finding cleanly.

No imports, new methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
