### PR TITLE
Potential fix for code scanning alert no. 20: Prototype-polluting function

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -146,6 +146,10 @@ function mergeConfig(target, source) {
     }
 
     for (const [key, value] of Object.entries(source)) {
+        if (isUnsafeKey(key)) {
+            continue;
+        }
+
         if (Array.isArray(value)) {
             target[key] = value.slice();
             continue;
@@ -160,6 +164,10 @@ function mergeConfig(target, source) {
     }
 
     return target;
+}
+
+function isUnsafeKey(key) {
+    return key === '__proto__' || key === 'constructor' || key === 'prototype';
 }
 
 function isPlainObject(value) {


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/20](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/20)

Use key sanitization in `mergeConfig` so unsafe keys are never copied or recursed into.

Best fix in this file: in `tailwind.config.js`, update the loop in `mergeConfig` to skip keys `__proto__`, `constructor`, and `prototype` before any assignment/recursion. This preserves existing functionality for all normal Tailwind config fields while preventing prototype chain mutation.

Changes needed:
- In `mergeConfig` (around lines 148–159), add a guard:
  - `if (isUnsafeKey(key)) continue;`
- Add a helper function in the same file:
  - `function isUnsafeKey(key) { return key === '__proto__' || key === 'constructor' || key === 'prototype'; }`

No import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
