### PR TITLE
Potential fix for code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -1400,8 +1400,10 @@ if ("undefined" == typeof jQuery)
             })
         }
         var c = function(b, d) {
-            this.options = a.extend({}, c.DEFAULTS, d),
-                this.$target = a(this.options.target).on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
+            this.options = a.extend({}, c.DEFAULTS, d);
+            var e = this.options.target;
+            "string" == typeof e && /^\s*</.test(e) && (e = window),
+                this.$target = a(e).on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
                 this.$element = a(b),
                 this.affixed = null,
                 this.unpin = null,


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/15](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/15)

General fix: ensure plugin option values used in jQuery constructor are constrained to safe types/values before calling `$()`. For `target`, allow only non-string DOM-like objects (`window`, `document`, elements, jQuery objects) or selector-like strings that are explicitly rejected if they look like HTML (`<...`).

Best minimal fix in this file: in `public/themes/Default/js/bootstrap.js`, inside the affix constructor (`var c = function(b, d) { ... }`), normalize `this.options.target` into a local `target` variable, reject HTML-like strings, and fall back to `window` when invalid. Then use `a(target)` instead of `a(this.options.target)` on line 1404. This preserves existing functionality for valid selectors/elements while preventing HTML interpretation from unsafe string input. No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
