### PR TITLE
Potential fix for code scanning alert no. 32: Unsafe jQuery plugin

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -1401,9 +1401,10 @@ if ("undefined" == typeof jQuery)
         }
         var c = function(b, d) {
             this.options = a.extend({}, c.DEFAULTS, d);
-            var e = this.options.target;
-            "string" == typeof e && /^\s*</.test(e) && (e = window),
-                this.$target = a(e).on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
+            var e = this.options.target
+                , f = "string" == typeof e ? a(a.find(e)) : a(e);
+            f.length || (f = a(window)),
+                this.$target = f.on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
                 this.$element = a(b),
                 this.affixed = null,
                 this.unpin = null,


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/32](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/32)

General fix: ensure plugin options that represent selectors are never passed to `jQuery(...)` in a way that can be interpreted as HTML. Prefer selector-only APIs (`jQuery.find`) for string values, and preserve existing behavior for DOM/jQuery/object values.

Best targeted fix in `public/themes/Default/js/bootstrap.js` (around lines 1404–1407): normalize `target` as follows:
- If `target` is a string, resolve it via `a.find(target)` and wrap the result with `a(...)`.
- If `target` is not a string, keep current behavior with `a(target)`.
- Keep fallback to `window` when selector lookup yields no result, maintaining functional behavior similar to prior fallback logic.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
