### PR TITLE
Potential fix for code scanning alert no. 14: Unsafe jQuery plugin

### DIFF
--- a/public/themes/Default/js/bootstrap.js
+++ b/public/themes/Default/js/bootstrap.js
@@ -815,7 +815,7 @@ if ("undefined" == typeof jQuery)
                     this.type = b,
                     this.$element = a(c),
                     this.options = this.getOptions(d),
-                    this.$viewport = this.options.viewport && a(a.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : this.options.viewport.selector || this.options.viewport),
+                    this.$viewport = this.options.viewport && this.getViewportElement(this.options.viewport),
                     this.inState = {
                         click: !1,
                         hover: !1,
@@ -842,6 +842,11 @@ if ("undefined" == typeof jQuery)
             ,
             c.prototype.getDefaults = function() {
                 return c.DEFAULTS
+            }
+            ,
+            c.prototype.getViewportElement = function(b) {
+                var c = a.isFunction(b) ? b.call(this, this.$element) : b.selector || b;
+                return "string" == typeof c ? a(a.find(c)) : a(c)
             }
             ,
             c.prototype.getOptions = function(b) {


### PR DESCRIPTION
Potential fix for [https://github.com/niyazialpay/AlphaBlog/security/code-scanning/14](https://github.com/niyazialpay/AlphaBlog/security/code-scanning/14)

General fix: avoid passing plugin-option-controlled values directly into `jQuery(...)` when the value may be interpreted as HTML. Normalize and validate `viewport` so selector strings are resolved via `jQuery.find` (selector-only parsing), and function-returned values are also constrained before use.

Best targeted fix in `public/themes/Default/js/bootstrap.js`:
- In `c.prototype.init` (around line 818), replace direct `a(...)` construction from `this.options.viewport...` with a safe helper that:
  - Executes the function if `viewport` is a function.
  - If result/value is a string, resolves via `a.find(...)` and wraps that result with `a(...)`.
  - If it is a DOM/jQuery/object value, pass through to `a(...)`.
  - Preserves current behavior for default `{selector:"body"}` and non-string values.
- Add a helper method on tooltip prototype (near other prototype methods) to keep logic centralized and minimal.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
